### PR TITLE
change of output name

### DIFF
--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -1064,7 +1064,7 @@ c
 c
           if (lFirst) then   ! open the file
            if(cl_docker) then
-             write(fname,'(A)') 'dvcs.dat'
+             write(fname,'(A)') 'dvcsgen.dat'
              cl_nmax=cl_triggers+100
            else
            if(ifile.le.9) then


### PR DESCRIPTION
As discussed with Mauri, the output name must be dvcsgen.dat, not dvcs.dat with docker flag. This is to comply with clas12-mcgen rules for all generator working on offsite farms.