### PR TITLE
Replacing rand() with random_number

### DIFF
--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -919,7 +919,8 @@ C**********************************************************************
 C      random number generator
 C**********************************************************************
          real function random_num()
-         random_num=rand()
+         CALL RANDOM_SEED()
+         CALL RANDOM_NUMBER(random_num)
          return
          end
 

--- a/mycernlib.F
+++ b/mycernlib.F
@@ -33,15 +33,15 @@ c
        implicit none
        REAL VEC(LEN)
        INTEGER i,LEN
-       DO i=1,LEN
-       VEC(i)=rand() 
-       ENDDO
+       CALL RANDOM_SEED()
+       CALL RANDOM_NUMBER(VEC)
        return
       end 
 c
 c
       REAL FUNCTION ZBQLU01(DUMMY)
-      ZBQLU01=rand() !rndm(-1)
+      CALL RANDOM_SEED()
+      CALL RANDOM_NUMBER(ZBQLU01)
       return
       end 
 c

--- a/mycernlib.F
+++ b/mycernlib.F
@@ -33,7 +33,7 @@ c
        implicit none
        REAL VEC(LEN)
        INTEGER i,LEN
-       CALL RANDOM_SEED()
+       CALL RANDOM_SEED(size=LEN)
        CALL RANDOM_NUMBER(VEC)
        return
       end 


### PR DESCRIPTION
rand() is outdated.
It has been recommended to use random_number instead of rand(). This is the case for the latest gfortran (See [https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gfortran.pdf]), or even for gfortran 4.8 (See [https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gfortran.pdf].
They explicitly describes " For new code, one should consider the use of Section 9.225 RANDOM NUMBER, page 255
as it implements a superior algorithm."
Therefore, I simply replaced rand() with all random_number().
This PR solves Mauri's troubleshooting "rndm flag #2 " at issue, because random_seed already initiates seed.