### PR TITLE
increase max length of pdf vars for long path of singularity in cvmfs…

### DIFF
--- a/dvcs_grid_pack.cc
+++ b/dvcs_grid_pack.cc
@@ -115,8 +115,8 @@ int     GPD_FindGridFile(const char *file)
   }
   
 
-  printf("Checking in $GPD_DATA_DIR\n");
-  env_dir = getenv("GPD_DATA_DIR");
+  printf("Checking in $CLASDVCS_PDF\n");
+  env_dir = getenv("CLASDVCS_PDF");
   if(env_dir!=NULL){
     printf("Lenght = %d\n",strlen(env_dir));
     sprintf(GPD_CurrentGridFile,"%s/%s",env_dir,file);
@@ -125,7 +125,7 @@ int     GPD_FindGridFile(const char *file)
       return 0;
     }
   } else {
-    printf("GPD_FindGridFile: the enviromental variable GPD_DATA_DIR is not defined\n");
+    printf("GPD_FindGridFile: the enviromental variable CLASDVCS_PDF is not defined\n");
   }
   
   

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -2522,7 +2522,7 @@ c
 *
       common/retbl1/ vh1urenf(51,21,2), vh1drenf(51,21,2) 
       common/imtbl1/ vh1uimnf(51,21,2), vh1dimnf(51,21,2)
-      character*200  pdffile,clasdvcspdf
+      character*500  pdffile,clasdvcspdf
 * 
       call getenv('CLASDVCS_PDF',clasdvcspdf)
        print *,'READING the gpd.dat from directory $CLASDVCS_PDF='


### PR DESCRIPTION
… and change GPD_DATA_DIR to CLASDVCS_PDF

Due to recent mount of singularity image in cvmfs, not in scosg16, the path length of pdf variables have become too long for char*100. This PR increases the size of char* variables related to pdf grid, i.e., ```clasdvcspdf``` and ```pdffile```.

Also, the path environment $GPD_DATA_DIR, used in dvcs_grid_pack (only used for --gpd 101 option, and desired for the larger t range) should be $CLASDVCS_PDF, like as the path for gpd.dat .