### PR TITLE
Three updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # dvcsgen
 dvcs/pi0/eta  generator using pdfs and gpds. 
+
+```
 git clone https://github.com/JeffersonLab/dvcsgen.git
 cd dvcsgen
 make
+```
+
+Please cite the following articles for this generator.
+```
+V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–
+461 (2002).
+I. Akushevich and A. Ilyichev, Phys. Rev. D 98, 013005 (2018).
+```
+
+The supplementary material of the following article contains the global fitting of the EM form factors.
+```
+Z. Ye, J. R. Arrington, R. J.Hill and G. Lee , Phys. Lett. B 777 (2018) 8–15
+```
 
 To get command line options `./dvcsgen --help`
 
@@ -55,6 +70,7 @@ will write `gemc lund type` single data file dvcs.dat with 10K events
       --mom                include moments in ntuple
       --proloss                  add proton loss
       --ktcor          FALSE   turn on k_t cor for A_LU
+      --globalfit      FALSE   use the global fitting results of EM form factors
       --radgen                   include radgen
       --radstable                use born cross sections for rejection sampling
       --nodat               do not write a data file

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I. Akushevich and A. Ilyichev, Phys. Rev. D 98, 013005 (2018).
 
 The supplementary material of the following article contains the global fitting of the EM form factors.
 ```
-Z. Ye, J. R. Arrington, R. J.Hill and G. Lee , Phys. Lett. B 777 (2018) 8–15
+Z. Ye, J. R. Arrington, R. J.Hill and G. Lee, Phys. Lett. B 777 (2018) 8–15
 ```
 
 To get command line options `./dvcsgen --help`

--- a/dvcs.inc
+++ b/dvcs.inc
@@ -11,7 +11,7 @@
       real  cl_sme,cl_smf,cl_smg,cl_rast
       logical dvcsgenOK,bosOK,ntOK,weightOK,cl_mom,cl_dvcs,cl_pi0,cl_eta
       logical bossmearOK,dalOK,cl_radgen,cl_radstable,datfileOK,acce16,acceg1,acc12
-      logical cl_ktcor,cl_printgpd,cl_docker
+      logical cl_ktcor,cl_printgpd,cl_docker,cl_global
       character*7 bosout
       common /OUT_NAMES/ bosout
       common /clasdvcs1/ cl_verblev,cl_nprint,cl_proloss,cl_writef,cl_seed
@@ -25,7 +25,7 @@
       common /clasdvcs9/ cl_sme,cl_smf,cl_smg,cl_rast,cl_delta,cl_vv2cut
       common /dvcsgencont/ dvcsgenOK,bosOK,ntOK,weightOK,bossmearOK,
      6cl_mom,cl_dvcs,cl_pi0,cl_eta,cl_radgen,cl_radstable,cl_mod,
-     6datfileOK,acce16,acceg1,acc12,cl_ktcor,cl_printgpd,cl_docker
+     6datfileOK,acce16,acceg1,acc12,cl_ktcor,cl_printgpd,cl_docker,cl_global
 C..
       double precision Mp, mele, pi,mpi0,metta
       parameter (Mp=0.93827D0)

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -210,6 +210,7 @@ c
       cl_printgpd=.FALSE.
       cl_mom=.FALSE.
       cl_ktcor=.FALSE.
+      cl_global=.FALSE.
       cl_radgen=.FALSE.
       cl_radstable=.FALSE.
       cl_mod=0              ! write all, otherwise filter
@@ -272,6 +273,8 @@ c
            cl_dvcs=.FALSE.
         elseif(cnumber.eq.'--ktcor') then
            cl_ktcor=.TRUE.
+        elseif(cnumber.eq.'--globalfit') then
+           cl_global=.TRUE.
         elseif(cnumber.eq.'--beam'.and.i.lt.numopts) then
            i=i+1
            CALL GETARG(i,cnumber)
@@ -492,7 +495,11 @@ c            asymmetries at 90-degree
              alu=hs1Iunp/(hc0BH+hc0dvcs+hc0Iunp)
 c           print *,'xbd,Q2d,del2',xbd,Q2d,del2d,del2min,del2max
       if( del2d.le.del2min .and. del2d.ge.del2max ) then  ! in limits
+      if (cl_global) then
+      call nuclFF_YAHL( del2d )
+      else
       call nuclFF( del2d )
+      endif
       skew = xbd/(2D0 - xbd)
       IF(IGPD.lt.100) then
       call amptab(skew, del2d, 
@@ -560,6 +567,7 @@ c
         print *,'     --mom                include moments in ntuple'
         print *,'     --proloss                  add proton loss'
         print *,'     --ktcor          FALSE   turn on k_t cor for A_LU'
+        print *,'     --globalfit      FALSE   use the global fitting results of EM form factors'
         print *,'     --radgen                   include bhradgen'
         print *,'     --radstable                use born cross sections for rejection sampling'
         print *,'     --nodat               do not write a data file'
@@ -772,7 +780,7 @@ c
                  tmax = min(-cl_tmin, t1lim)
                  tmin = max(-cl_tmax, t2lim)
                  if (tmax<tmin) then
-                    continue
+                    cycle
                  endif
               dt=(tmax-tmin)/nt
               del2d=tmin+it*dt
@@ -782,6 +790,7 @@ c
                phield=ife*dfe
                cife=1.0
                if(ife.eq.1.or.ife.eq.nx) cife=0.5
+               if(cl_pol.le.1) cife = 1
                DO ifg=1,nfg
                 phigd=ifg*dfg
                 cifg=1.0
@@ -927,6 +936,9 @@ C         endif
                  t1lim=-0.5d0*((Q2d/xbd-Q2d)*(Q2d/xbd-sqrt((Q2d/xbd)**2+4d0*Mp*Mp*Q2d))+2d0*Mp*Mp*Q2d)/w2
                  tmax = min(-cl_tmin, t1lim)
                  tmin = max(-cl_tmax, t2lim)
+        if (tmax<tmin) then
+            goto 10
+        endif
 
         del2d=tmin+(tmax-tmin)*VEC(3)
 ccc- Hyon-Suk
@@ -970,7 +982,7 @@ C..     Generation of an event in GENDVCS
                     radq2 = Q2d
                     radxb = xbd
                     radt = del2d
-                    radphi = pi - phigd
+                    radphi = phigd
                     iproctype = ichannel
                     PhRAD(4) = egamma
             else
@@ -2098,7 +2110,11 @@ c
       phip = phigd 
       phipel = phield 
 *
+      if (cl_global) then
+      call nuclFF_YAHL( del2d )
+      else
       call nuclFF( del2d )
+      endif
 *
       y1eps=1D0 - yb - yb*yb*eps2/4D0
       sqy1eps=sqrt(y1eps)
@@ -2717,6 +2733,55 @@ C
       F2pn(2) = (GM_n - GE_n)/(1D0-delm)         
       return
       end
+
+      subroutine nuclFF_YAHL( del2 )
+C from the supplementary material of
+C Zhihong Ye, John R. Arrington, Richard J.Hill and Gabriel Lee 
+C "Proton and neutron electromagnetic form factors and uncertainties"
+C Phys. Lett. B 777 (2018) 8--15
+C doi: 10.1016/j.physletb.2017.11.023
+C
+C added by Sangbaek Lee
+C
+C
+      implicit double precision (A-H,O-Z)
+#include "dvcs.inc"
+      common/formfac/ F1pn(2), F2pn(2)
+      double precision Mv, kp, mu_n
+      double precision z, a0(4), a1(4), a2(4), a3(4), a4(4), a5(4), a6(4), a7(4), a8(4), a9(4), a10(4), a11(4), a12(4)
+      parameter (Mv = 0.843D0, kp = 1.79285D0, mu_n = -1.91D0, tcut = 4*0.13957**2, t0 = -0.7)
+C
+      dipol = 1D0/(1D0 - del2/Mv**2)**2
+      z = (sqrt(tcut-del2)-sqrt(tcut-t0))/(sqrt(tcut-del2)+sqrt(tcut-t0)) 
+*
+      a0 = (/ 0.239163298067, 0.264142994136, 0.048919981379, 0.257758326959 /)
+      a1 = (/ -1.109858574410, -1.095306122120, -0.064525053912, -1.079540642058 /)
+      a2 = (/ 1.444380813060, 1.218553781780, -0.240825897382, 1.182183812195 /)
+      a3 = (/ 0.479569465603, 0.661136493537, 0.392108744873, 0.711015085833 /)
+      a4 = (/ -2.286894741870, -1.405678925030, 0.300445258602, -1.348080936796 /)
+      a5 = (/ 1.126632984980, -1.356418438880, -0.661888687179, -1.662444025208 /)
+      a6 = (/ 1.250619843540, 1.447029155340, -0.175639769687, 2.624354426029 /)
+      a7 = (/ -3.631020471590, 4.235669735900, 0.624691724461, 1.751234494568 /)
+      a8 = (/ 4.082217023790, -5.334045653410, -0.077684299367, -4.922300878888 /)
+      a9 = (/ 0.504097346499, -2.916300520960, -0.236003975259, 3.197892727312 /)
+      a10 = (/ -5.085120460510, 8.707403067570, 0.090401973470, -0.712072389946 /)
+      a11 = (/ 3.967742543950, -5.706999943750, 0.0, 0.0 /)
+      a12 = (/ -0.981529071103, 1.280814375890, 0.0, 0.0 /)
+
+      GE_p = (a0(1)*z**0+a1(1)*z**1+a2(1)*z**2+a3(1)*z**3+a4(1)*z**4+a5(1)*z**5+a6(1)*z**6+a7(1)*z**7+a8(1)*z**8+a9(1)*z**9+a10(1)*z**10+a11(1)*z**11+a12(1)*z**12)
+      GM_p = (1D0 + kp)*(a0(2)*z**0+a1(2)*z**1+a2(2)*z**2+a3(2)*z**3+a4(2)*z**4+a5(2)*z**5+a6(2)*z**6+a7(2)*z**7+a8(2)*z**8+a9(2)*z**9+a10(2)*z**10+a11(2)*z**11+a12(2)*z**12)
+      GE_n = (a0(3)*z**0+a1(3)*z**1+a2(3)*z**2+a3(3)*z**3+a4(3)*z**4+a5(3)*z**5+a6(3)*z**6+a7(3)*z**7+a8(3)*z**8+a9(3)*z**9+a10(3)*z**10+a11(3)*z**11+a12(3)*z**12)
+      GM_n = mu_n*(a0(4)*z**0+a1(4)*z**1+a2(4)*z**2+a3(4)*z**3+a4(4)*z**4+a5(4)*z**5+a6(4)*z**6+a7(4)*z**7+a8(4)*z**8+a9(4)*z**9+a10(4)*z**10+a11(4)*z**11+a12(4)*z**12)
+*
+      delm = del2/(2D0*Mp)**2
+*
+      F1pn(1) = (GE_p - delm*GM_p)/(1D0-delm)
+      F1pn(2) = (GE_n - delm*GM_n)/(1D0-delm)
+      F2pn(1) = (GM_p - GE_p)/(1D0-delm)         
+      F2pn(2) = (GM_n - GE_n)/(1D0-delm)         
+      return
+      end
+
 
       subroutine V3subd( A, B, C)
       implicit double precision (A-H,O-Z)

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -816,7 +816,7 @@ c
               stop
              endif
 c
-             stotint=stotint+dstot*cix*cit*ciq*cife*cifg
+             if (dstot>0) stotint=stotint+dstot*cix*cit*ciq*cife*cifg*dx*dt*dq*dfe*dfg
 c
            if(smax.lt.dstot) then
             smax=dstot
@@ -838,7 +838,7 @@ c        print *,'bad-y',xmin,xmax,xbd,q2min,q2max,q2d,del2d
        ENDDO
        ENDDO
        if(cl_verblev.gt.-1) print *,'Maximum found at',SMAX,
-     6'x-sec(pb) = ',stotint*dx*dt*dq*dfe*dfg,dx*dt*dq*dfe*dfg
+     6'x-sec(pb) = ',stotint
           ENDDO
          ENDDO
         return

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -987,6 +987,12 @@ C..     Generation of an event in GENDVCS
                     PhRAD(4) = egamma
             else
                 CALL bmkxsec(xbd, Q2d, del2d, phield,phigd,dstot)
+                    bornweight = dstot
+                    radweight = dstot
+                    radq2 = Q2d
+                    radxb = xbd
+                    radt = del2d
+                    radphi = phigd
             endif
         else
         CALL excpi0(xbd, Q2d, del2d, phield,phigd,dstot)


### PR DESCRIPTION
- force t_max<t<t_min, for the precise integration before passing it to bmkxsec (so far the subroutine bmkxsec did the job).
- adds the global fitting of the form factors
- now saves the phi angle in the Trento Convention, not in BMK.