### PR TITLE
Encode the NaN and Infinity as zero (0).

### DIFF
--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -628,7 +628,7 @@ c
      6,cl_proloss  
         print *,'__________________________________'
         print *,'verbosity level',  cl_verblev
-	if(cl_tmax.gt.0.5.and.cl_dvcs.and.cl_gpd.lt.100) then
+	if(cl_tmax.gt.1.0.and.cl_dvcs.and.cl_gpd.lt.100) then
 	  print *,'t>0.5 not supported for --gpd <100:  ',cl_tmax
 	  call exit(-1)
 	endif 
@@ -813,6 +813,9 @@ c
                     ebeamff = cl_beam_energy
                     ikeygene = 4
                     CALL bhradgen(ebeamff, xff, q2ff, tff, phiff,cl_vv2cut,cl_delta,egamma,thetag,phig,ichannel,cl_pol,ikeygene,dstot)
+                    if (isnan(dstot).or.(dstot.le.0).or.(dstot.gt.huge(dstot))) then
+                     dstot = 0
+                    endif                    
                     dstot = dstot/2.0/pi
                 else
                     CALL bmkxsec(xbd, Q2d, del2d, phield,phigd,dstot)
@@ -983,6 +986,9 @@ C..     Generation of an event in GENDVCS
                     CALL bmkxsec(xbd, Q2d, del2d, phield,phigd,dstot)
                     bornweight = dstot
                     CALL bhradgen(ebeamff, xff, q2ff, tff, phiff,cl_vv2cut,cl_delta,egamma,thetag,phig,ichannel,cl_pol,ikeygene,dstot)
+                    if (isnan(dstot).or.(dstot.le.0).or.(dstot.gt.huge(dstot))) then
+                     dstot = 0
+                    endif
                     dstot = dstot/2.0/pi
                     radweight = dstot
                     radq2 = Q2d


### PR DESCRIPTION
The radiative cross sections are sometimes +Infinity or NaN if there's a technical issue with the integral.
This generates a new issue with the current version of GEMC that the GEMC can't read the events with NaN and Infinity cross sections.
Among 1M events simulated at ifarm, there are only 457 events with NaN and 112 events with Infinity.
Hence, an event has NaN or Infinity as the differential cross section cross section will be treated as zero cross section events after this commit.
This will mitigate the issue that the GEMC5.

At the same time, I increased the tmax from 0.5 to 1.0 for gpd<100, because ```gpd.dat``` actually supports |t| up to 1 GeV^2.
At subroutine amptab, line 2504 of dvcsgen.F,
```
        dlmin    = 0.01D0
        dlmax    = 1.00D0
```