### PR TITLE
Update the external radiative correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ will write `gemc lund type` single data file dvcs.dat with 10K events
       --ktcor          FALSE   turn on k_t cor for A_LU
       --globalfit      FALSE   use the global fitting results of EM form factors
       --radgen                   include radgen
+      --radext                   include external radiative corrections
       --radstable                use born cross sections for rejection sampling
       --nodat               do not write a data file
       --acce16            include e16 acceptance for e-
@@ -93,7 +94,7 @@ will write `gemc lund type` single data file dvcs.dat with 10K events
 For the writef 2 option, the file format is still lund, [https://gemc.jlab.org/gemc/html/documentation/generator/lund.html](https://gemc.jlab.org/gemc/html/documentation/generator/lund.html).
 
 But the contents are changed for the radiative corrections.
-So, --writef 2 is only useful when --radgen is on.
+So, ```--writef 2``` is only useful when ```--radgen``` is on.
 
 The header's event weight is still the radiative cross section (weight of MC::Header).
 
@@ -104,4 +105,8 @@ The electron: (2) xB, (6) radiation mode (1: nonrad, 2:s-peak, 3:p-peak), (10) Q
 
 The proton: (2) phi (radians), (10) shifted xB of the virtual photon, (11) shifted Q2 of the virtual photon.
 
-The photon: (11) born cross section.
+The photon: (2) actual beam electron energy (See ```External Radiative Corrections``` below), (11) born cross section.
+
+## External Radiative Corrections
+
+For the realistic radiative generators, the external radiative corrections are required for the incoming electron because the interactions between the beam electron and the target materials happen prior to the vertex. So far, the program is reducing the energy only, without considering the angle smearing from the multiple scattering. The energy loss formula is from the approximation by Mo & Tsai (1969) [https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.41.205](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.41.205). The materials depends on the target configuration. So far, this option assumes the RG-A target geometry only. One can turn on the external RC by adding ```--radext``` option. If ```--writef 2``` is turned on, the photon's (2) lifetime column will record the actual incoming electron energy.

--- a/dvcs.inc
+++ b/dvcs.inc
@@ -10,7 +10,7 @@
       real  cl_sma,cl_smb,cl_smc,cl_smd
       real  cl_sme,cl_smf,cl_smg,cl_rast
       logical dvcsgenOK,bosOK,ntOK,weightOK,cl_mom,cl_dvcs,cl_pi0,cl_eta
-      logical bossmearOK,dalOK,cl_radgen,cl_radstable,datfileOK,acce16,acceg1,acc12
+      logical bossmearOK,dalOK,cl_radgen,cl_radext,cl_radstable,datfileOK,acce16,acceg1,acc12
       logical cl_ktcor,cl_printgpd,cl_docker,cl_global
       character*7 bosout
       common /OUT_NAMES/ bosout
@@ -24,7 +24,7 @@
       common /clasdvcs8/ cl_smear,cl_sma,cl_smb,cl_smc,cl_smd
       common /clasdvcs9/ cl_sme,cl_smf,cl_smg,cl_rast,cl_delta,cl_vv2cut
       common /dvcsgencont/ dvcsgenOK,bosOK,ntOK,weightOK,bossmearOK,
-     6cl_mom,cl_dvcs,cl_pi0,cl_eta,cl_radgen,cl_radstable,cl_mod,
+     6cl_mom,cl_dvcs,cl_pi0,cl_eta,cl_radgen,cl_radext,cl_radstable,cl_mod,
      6datfileOK,acce16,acceg1,acc12,cl_ktcor,cl_printgpd,cl_docker,cl_global
 C..
       double precision Mp, mele, pi,mpi0,metta

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -894,6 +894,7 @@ c
         LEN=8
         ITRY=0
  10     CALL MYRANMAR(VEC,LEN)
+        Ed = cl_beam_energy
         ITRY=ITRY+1
         xbd=xmin+(xmax-xmin)*VEC(1)
         Q2d=q2min+(q2max-q2min)*VEC(2)

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -212,6 +212,7 @@ c
       cl_ktcor=.FALSE.
       cl_global=.FALSE.
       cl_radgen=.FALSE.
+      cl_radext=.FALSE.
       cl_radstable=.FALSE.
       cl_mod=0              ! write all, otherwise filter
       datfileOK=.TRUE.      ! write a data file
@@ -261,6 +262,8 @@ c
            cl_pol=2
         elseif(cnumber.eq.'--radgen') then
            cl_radgen=.TRUE.
+        elseif(cnumber.eq.'--radext') then
+           cl_radext=.TRUE.
         elseif(cnumber.eq.'--radstable') then
            cl_radstable=.TRUE.
         elseif(cnumber.eq.'--mom') then
@@ -613,6 +616,7 @@ c
         print *,'GPD model A,B,C,D:   ', cl_gpd 
         print *,'GPD sinphi scale:   ', cl_scale 
         print *,'BHRADGEN ON        :   ', cl_radgen 
+        print *,'External Radiative Correct ON        :   ', cl_radext 
         print *,'Use Born Cross sections when bhradgen on :   ', cl_radstable
         print *,'y_col cut        :   ', cl_ycol 
         print *,'acceptance       :   ',acceg1,acce16,acc12
@@ -985,7 +989,11 @@ C..     Generation of an event in GENDVCS
                     CALL bmkxsec(xbd, Q2d, del2d, phield,phigd,dstot)
                     bornweight = dstot
                     if (isnan(bornweight).or.(bornweight.le.0).or.(bornweight.gt.huge(bornweight))) goto 10
-                    ebeamff = beam_energy - beam_energy * random_num()**(3./4./ (randnum*cl_zwidth/67.92 + 0.003/4.419))
+                    if (cl_radext) then
+                     ebeamff = beam_energy - beam_energy * random_num()**(3./4./ (randnum*cl_zwidth/67.92 + 0.003/4.419))
+                    else
+                     ebeamff = beam_energy 
+                    endif
                     ! External radiative correction, following L. W. Mo and Y. S. Tsai. Rev. Mod. Phys. 41, 205–235, 1969.
                     ! Inverse transform sampling, dE = E0 * r ^ (1/bT), where the distribution is I(x) = bT*(x)^(bT-1), where 0<x=dE/E<1.
                     ! T is the material thickness in units of radiation length.

--- a/dvcsgen.F
+++ b/dvcsgen.F
@@ -875,7 +875,7 @@ C..
         common /xmax/  xmax,xmin,q2max,q2min,tmax,tmin 
      6                 ,nx,nq,nt,nfe,nfg
 C..     generate a DVCS event
-      double precision xbd,Q2d,del2d,phield,phigd,dstot,yb,w2
+      double precision xbd,Q2d,del2d,phield,phigd,dstot,yb,w2, costgg
 c
 c       radiative stuff
 c
@@ -1036,7 +1036,8 @@ c
           if(dstot.le.smax*VEC(6)) goto 10 ! use x-section
         endif
         if(cl_dvcs) then
-           call getphoton(xbd,Q2d,del2d,phield,phigd)
+           call getphoton(xbd,Q2d,del2d,phield,phigd,costgg)
+           if (costgg>1) goto 10
         else
            call getpi0(xbd,  Q2d, del2d,phield,phigd)
         endif
@@ -3090,7 +3091,7 @@ c
       return
       end
 c
-      subroutine getphoton(xbd,Q2d,del2d,phield,phigd)
+      subroutine getphoton(xbd,Q2d,del2d,phield,phigd,costgg)
 c
 C     set to 0 all moments
       implicit none
@@ -3170,6 +3171,8 @@ c
             endif
          else
             call V3subd( V3k1, V3k2, V3q)
+            nu = Ed-Esc
+            qmod =  sqrt(V3q(1)**2 + V3q(2)**2 + V3q(3)**2)
          endif
       else
             call V3subd( V3k1, V3k2, V3q)


### PR DESCRIPTION
This PR corrects the urgent issues with the external RCs.
 
- Reset the beam energy for the every trial, so that the external RC can be done once at the loop.
- Correct the kinematics of the particles from the erroneous calculation of $|\vec{q}|$.
- Add the flag to control the external RC, especially for the run groups who are not the RG-A.
- Updated the README accordingly.