### PR TITLE
Correct the citation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,24 @@ cd dvcsgen
 make
 ```
 
-Please cite the following articles for this generator.
+Please cite this generator for publication.
 ```
-V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–
-461 (2002).
+H. Avakian, The dvcsgen generator, available at https://github.com/JeffersonLab/dvcsgen
+```
+
+If `--gpd` options used GPD model 1—4, please cite this article.
+```
+V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–461 (2002).
+```
+
+`--gpd 101` option uses CFF grid created by G. Gavalian. The following article is related.
+```
+G. Gavalian et al. (CLAS), Phys. Rev. C 80, 035206 (2009).
+```
+
+
+If radiative correction is used, please cite this article.
+```
 I. Akushevich and A. Ilyichev, Phys. Rev. D 98, 013005 (2018).
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I. Akushevich and A. Ilyichev, Phys. Rev. D 98, 013005 (2018).
 
 The supplementary material of the following article contains the global fitting of the EM form factors.
 ```
-Z. Ye, J. R. Arrington, R. J.Hill and G. Lee, Phys. Lett. B 777 (2018) 8–15
+Z. Ye, J. R. Arrington, R. J.Hill and G. Lee, Phys. Lett. B 777 (2018) 8–15.
 ```
 
 To get command line options `./dvcsgen --help`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please cite this generator for publication.
 H. Avakian, The dvcsgen generator, available at https://github.com/JeffersonLab/dvcsgen
 ```
 
-`--gpd 101` option uses CFF grid created by G. Gavalian. The following article is related.
+`--gpd 101` option uses CFF grid (VGG model with D-term) created by G. Gavalian. The following article is related.
 ```
 G. Gavalian et al. (CLAS), Phys. Rev. C 80, 035206 (2009).
 ```

--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ Please cite this generator for publication.
 H. Avakian, The dvcsgen generator, available at https://github.com/JeffersonLab/dvcsgen
 ```
 
-If `--gpd` options used GPD model 1—4, please cite this article.
-```
-V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–461 (2002).
-```
-
 `--gpd 101` option uses CFF grid created by G. Gavalian. The following article is related.
 ```
 G. Gavalian et al. (CLAS), Phys. Rev. C 80, 035206 (2009).
 ```
 
+If `--gpd` options used GPD model 1—4, please cite this article.
+```
+V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–461 (2002).
+```
 
 If radiative correction is used, please cite this article.
 ```


### PR DESCRIPTION
I would like to correct my mistake for providing vague citation guide.

```
V. A. Korotkov and W. D. Nowak, Eur. Phys. J. C 23, 455–461 (2002).
```
only describes the CFF for GPD models A-D, but should not be able to represent this detector.

Instead, I suggest we use

```
H. Avakian, The dvcsgen generator, available at https://github.com/JeffersonLab/dvcsgen
```

as the standard citation for this event generator.

I clarified the relation of other papers to this event generator.